### PR TITLE
fixed compilation when omp is not available

### DIFF
--- a/examples/SimFit.cpp
+++ b/examples/SimFit.cpp
@@ -12,7 +12,9 @@
 #include "AmpGen/Kinematics.h"
 #include "AmpGen/Generator.h"
 #include "AmpGen/PolarisedSum.h"
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "TRandom3.h"
 #include "TFile.h"
@@ -22,33 +24,33 @@ using namespace AmpGen;
 
 int main(int argc , char* argv[] ){
   OptionsParser::setArgs( argc, argv );
-  
-  const auto pEventType      = NamedParameter<std::string>("EventType", std::vector<std::string>(), 
+
+  const auto pEventType      = NamedParameter<std::string>("EventType", std::vector<std::string>(),
         "EventType to fit, in the format: \033[3m parent daughter1 daughter2 ... \033[0m" ).getVector();
-  
-  const auto datasets        = NamedParameter<std::string>("Datasets","", 
+
+  const auto datasets        = NamedParameter<std::string>("Datasets","",
       "List of data/simulated samples to fit, in the format \
       \033[3m data[0] sim[0] data[1] sim[1] ... \033[0m. \nIf a simulated sample is specified FLAT, uniformly generated phase-space events are used for integrals ").getVector();
-  
-  const std::string logFile  = NamedParameter<std::string>("LogFile"   , "Fitter.log", 
+
+  const std::string logFile  = NamedParameter<std::string>("LogFile"   , "Fitter.log",
       "Name of the output log file");
-  
-  const std::string plotFile = NamedParameter<std::string>("Plots"     , "plots.root", 
+
+  const std::string plotFile = NamedParameter<std::string>("Plots"     , "plots.root",
       "Name of the output plot file");
 
   std::vector<EventList>             data;
-  std::vector<EventList>              mcs; 
-  
-  #ifdef _OPENMP 
+  std::vector<EventList>              mcs;
+
+  #ifdef _OPENMP
     size_t hwThreads = std::thread::hardware_concurrency();
     size_t usThreads = NamedParameter<size_t>( "nCores", hwThreads, "Number of cores to use (OpenMP only)" );
     INFO("Using: " << usThreads  << " / " << hwThreads << " threads" );
     omp_set_num_threads(usThreads);
     omp_set_dynamic(0);
   #endif
-  
+
   INFO("Output : " << logFile << " plots = " << plotFile );
-  
+
   if( pEventType.size() == 0 ) FATAL("Must specify event format as EventType \033[3m parent daughter1 daughter2 ... \033[0m in options");
 
   const EventType eventType  = EventType( pEventType );
@@ -59,12 +61,12 @@ int main(int argc , char* argv[] ){
     else mcs.emplace_back( datasets[i+1], eventType, GetGenPdf(true) );
   }
 
-  std::vector<PolarisedSum>           fcs(data.size()); 
-  std::vector<SumPDF<EventList, PolarisedSum&>> pdfs; 
-  
-  pdfs.reserve(data.size()); 
+  std::vector<PolarisedSum>           fcs(data.size());
+  std::vector<SumPDF<EventList, PolarisedSum&>> pdfs;
 
-  SimFit totalLL; 
+  pdfs.reserve(data.size());
+
+  SimFit totalLL;
   MinuitParameterSet mps;
   mps.loadFromStream();
   for(size_t i = 0; i < data.size(); ++i){
@@ -72,21 +74,21 @@ int main(int argc , char* argv[] ){
     pdfs.emplace_back( make_pdf(fcs[i]) );
     pdfs[i].setEvents(data[i]);
     auto& mc = mcs[i];
-    for_each( pdfs[i].pdfs(), [&mc](auto& pdf){pdf.setMC(mc);});  
+    for_each( pdfs[i].pdfs(), [&mc](auto& pdf){pdf.setMC(mc);});
     totalLL.add( pdfs[i] );
-  } 
+  }
   Minimiser mini( totalLL, &mps );
-  mini.doFit();  
+  mini.doFit();
   FitResult(mini).writeToFile("Fitter.log");
   TFile* output_plots = TFile::Open( plotFile.c_str(), "RECREATE");
   for( size_t i = 0 ; i < data.size(); ++i )
   {
     INFO("Making figures for sample: " << i << " ...");
-    auto dataPlots = data[i].makeDefaultProjections( Prefix("Data_"+std::to_string(i))); 
+    auto dataPlots = data[i].makeDefaultProjections( Prefix("Data_"+std::to_string(i)));
     for( auto& p : dataPlots ) p->Write();
     size_t counter = 0;
     for_each(pdfs[i].pdfs(), [&]( auto& f ){
-      auto mc_plots = mcs[i].makeDefaultProjections(WeightFunction(f), 
+      auto mc_plots = mcs[i].makeDefaultProjections(WeightFunction(f),
         Prefix("Model_sample_"+std::to_string(i)+"_cat"+std::to_string(counter)));
       for( auto& plot : mc_plots )
       {


### PR DESCRIPTION
An example was missing the check for OPENMP, resulting in compilation failures into systems that are missing it.
Apologies for the whitespace changes...Only real change in L15.