### PR TITLE
small fixes

### DIFF
--- a/options/example_radiative.opt
+++ b/options/example_radiative.opt
@@ -1,14 +1,17 @@
-EventType D- K- pi+ pi- gamma0 
+EventType D- K- pi+ pi- gamma0
 
 Type PolarisedSum
+
+Particle::SpinBasis Weyl
+
 CouplingConstant::Coordinates  polar
 CouplingConstant::AngularUnits   deg
 
-K(1)(1270)bar-{rho(770)0{pi+,pi-},K-}                              2              1.000          0.000          2                 0.0         0.0              
-K(1)(1270)bar-{rho(1450)0{pi+,pi-},K-}                             0              2.016          0.026          0              -119.5         0.9      
+K(1)(1270)bar-{rho(770)0{pi+,pi-},K-}                              2              1.000          0.000          2                 0.0         0.0
+K(1)(1270)bar-{rho(1450)0{pi+,pi-},K-}                             0              2.016          0.026          0              -119.5         0.9
 K(1)(1270)bar-{K*(892)bar0{K-,pi+},pi-}                            0              0.388          0.007          0              -172.6         1.1
 K(1)(1270)bar-{KPi2bar0[FOCUS.Kpi]{K-,pi+},pi-}                    0              0.554          0.010          0                53.2         1.1
-K(1)(1270)bar-[D]{K*(892)bar0{K-,pi+},pi-}                          0              0.769          0.021          0               -19.3         1.6      
+K(1)(1270)bar-[D]{K*(892)bar0{K-,pi+},pi-}                          0              0.769          0.021          0               -19.3         1.6
 K(1)(1270)bar-{omega(782)0{pi+,pi-},K-}                            0              0.146          0.005          0                 9.0         2.1
 
 

--- a/src/EventType.cpp
+++ b/src/EventType.cpp
@@ -39,7 +39,7 @@ EventType::EventType( const std::vector<std::string>& particleNames, const bool&
     ERROR( "Particle not found: " << m_mother );
     return;
   }
-  m_alt_part_names = NamedParameter<bool>("EventType::AlternativeParicleNames", false );
+  m_alt_part_names = NamedParameter<bool>("EventType::AlternativeParticleNames", false );
   for ( auto& particle : m_particleNames ) {
     auto prop = ParticlePropertiesList::get( particle );
     if ( prop != nullptr )

--- a/src/EventType.cpp
+++ b/src/EventType.cpp
@@ -49,7 +49,7 @@ EventType::EventType( const std::vector<std::string>& particleNames, const bool&
       return;
     }
     if(m_alt_part_names)
-      m_particleNamesPickled.push_back( replaceAll( replaceAll( particle, "+", "p" ), "-", "m" ) );
+      m_particleNamesPickled.push_back( replaceAll( replaceAll( replaceAll( replaceAll( particle, "+", "p" ), "-", "m" ), "(", "" ) , ")", "" ) );
     else
       m_particleNamesPickled.push_back( replaceAll( replaceAll( particle, "+", "~" ), "-", "#" ) );
   }
@@ -100,7 +100,7 @@ std::pair<double, double> EventType::minmax( const std::vector<unsigned>& indice
 {
   std::vector<unsigned> ivec( size() );
   std::iota( ivec.begin(), ivec.end(), 0 );
-  double min = 0 ; 
+  double min = 0 ;
   for( auto& i : indices ) min += mass(i);
   double max = motherMass();
   for ( auto& x : ivec )


### PR DESCRIPTION
- fix typo in AlternativeParticleNames option: AlternativeParicleNames -> AlternativeParticleNames
- fix seg-faulting example: Particle::SpinBasis Weyl for example with radiative decay