### PR TITLE
Minor changes to CompilerWrapper to help with troubleshooting.

### DIFF
--- a/src/CompilerWrapper.cpp
+++ b/src/CompilerWrapper.cpp
@@ -34,12 +34,16 @@ CompilerWrapper::CompilerWrapper( const bool& verbose ) :
   if ( m_cxx == "" ) {
 #ifdef AMPGEN_CXX
     if( m_verbose ) 
-      INFO( "Using original compiler; set global variable CXX if another needed: " << AMPGEN_CXX );
+      INFO( "Global variable CXX is undefined, using compiler variable AMPGEN_CXX: " << AMPGEN_CXX );
     m_cxx = AMPGEN_CXX;
 #else
     m_cxx = getenv("AMPGEN_CXX") != nullptr ? std::string( getenv( "AMPGEN_CXX" ) ) : "";
     if( m_cxx == "" ) ERROR( "No configured compiler; set global variable CXX" );
 #endif
+  }
+  else {
+    if( m_verbose ) 
+      INFO( "Global variable CXX is defined: " << m_cxx << "; AMPGEN_CXX is ignored" ); // to use AMPGEN_CXX, unset CXX
   }
 }
 
@@ -133,7 +137,7 @@ void CompilerWrapper::compileSource( const std::string& fname, const std::string
     "-rdynamic", 
     "-fPIC"};
   std::transform( compile_flags.begin(), compile_flags.end(), std::back_inserter(argp), [](const auto& flag ){return flag.c_str() ; } );
-  if( m_cxx.find("clang") != std::string::npos ) 
+  if( m_cxx.find("clang") != std::string::npos || m_cxx.find("llvm-g++") != std::string::npos) 
     argp.push_back( "-Wno-return-type-c-linkage");
 
   argp.push_back( fname.c_str() );
@@ -151,7 +155,7 @@ void CompilerWrapper::compileSource( const std::string& fname, const std::string
   if( childPID == 0 )
   {
     execv( argp[0], const_cast<char**>( &argp[0] ) );
-    perror( "execl()" );
+    perror( "execv() in ../src/CompilerWrapper.cpp" ); // add "CompilerWrapper::Verbose true" to .opt file to diagnose
     exit( 0 );
   }
   int status = 0;   

--- a/src/CompilerWrapper.cpp
+++ b/src/CompilerWrapper.cpp
@@ -137,7 +137,8 @@ void CompilerWrapper::compileSource( const std::string& fname, const std::string
     "-rdynamic", 
     "-fPIC"};
   std::transform( compile_flags.begin(), compile_flags.end(), std::back_inserter(argp), [](const auto& flag ){return flag.c_str() ; } );
-  if( m_cxx.find("clang") != std::string::npos || m_cxx.find("llvm-g++") != std::string::npos) 
+  if( m_cxx.find("clang") != std::string::npos || m_cxx.find("llvm-g++") != std::string::npos)
+  {
     argp.push_back( "-Wno-return-type-c-linkage");
     #if __APPLE__
     argp.push_back("-lstdc++");


### PR DESCRIPTION
A couple minor changes to src/CompilerWrapper.cpp, which should help with troubleshooting if execv() fails. Also, a small change to remove [-Wreturn-type-c-linkage] warnings should someone choose to use LLVM's clang softlink when specifying their compiler.