### PR TITLE
allow mutliple Kmatrices in same model

### DIFF
--- a/src/Lineshapes/GenericKmatrix.cpp
+++ b/src/Lineshapes/GenericKmatrix.cpp
@@ -18,7 +18,7 @@
 #include "AmpGen/CoupledChannel.h"
 
 using namespace AmpGen;
-using namespace AmpGen::fcn; 
+using namespace AmpGen::fcn;
 
 DEFINE_LINESHAPE(GenericKmatrix)
 {
@@ -27,40 +27,40 @@ DEFINE_LINESHAPE(GenericKmatrix)
   INFO( "kMatrix modifier " << lineshapeModifier << " particle = " << particleName );
   auto tokens = split(lineshapeModifier, '.' );
   DEBUG("kMatrix modifier = " << lineshapeModifier << " nTokens = " << tokens.size() );
-  unsigned nPoles    = NamedParameter<unsigned>(     lineshapeModifier + "::kMatrix::nPoles");
-  auto channels    = NamedParameter<std::string>(lineshapeModifier + "::kMatrix::channels").getVector();
+  unsigned nPoles  = NamedParameter<unsigned>(lineshapeModifier+"::"+particleName+"::kMatrix::nPoles");
+  auto channels    = NamedParameter<std::string>(lineshapeModifier+"::"+particleName+"::kMatrix::channels").getVector();
   unsigned nChannels = channels.size();
   std::vector<Expression> phsps;
   std::vector<Expression> bw_phase_space;
   auto s0 = mass*mass;
   ADD_DEBUG(s, dbexpressions );
   ADD_DEBUG(s0, dbexpressions );
-  INFO("Initialising K-matrix with [nChannels = " << nChannels << ", nPoles = " << nPoles << "]"); 
+  INFO("Initialising K-matrix with [nChannels = " << nChannels << ", nPoles = " << nPoles << "]");
   for( unsigned i = 0 ; i < channels.size(); i+=1 ){
-    Particle p( channels[i] ); 
+    Particle p( channels[i] );
     INFO( p.decayDescriptor() );
     phsps.emplace_back( phaseSpace(s, p, p.L() ) );
     bw_phase_space.emplace_back( phaseSpace(s0, p, p.L() ) );
     if( dbexpressions != nullptr ) dbexpressions->emplace_back("phsp_"+p.decayDescriptor(), *phsps.rbegin() ); //ADD_DEBUG( *phsps.rbegin(), dbexpressions);
-//    ADD_DEBUG( phaseSpace(s0,p,p.L()), dbexpressions );  
+//    ADD_DEBUG( phaseSpace(s0,p,p.L()), dbexpressions );
   }
   Tensor non_resonant( Tensor::dim(nChannels, nChannels) );
   std::vector<poleConfig> poleConfigs;
   for (unsigned pole = 1; pole <= nPoles; ++pole ){
-    std::string stub = lineshapeModifier + "::pole::" + std::to_string(pole);
+    std::string stub = lineshapeModifier+"::"+particleName+"::pole::" + std::to_string(pole);
     Expression mass  = Parameter(stub + "::mass");
     INFO( "Will link to parameter: " << stub + "::mass");
     poleConfig thisPole(mass*mass);
     if( dbexpressions != nullptr ) dbexpressions->emplace_back(stub+"::mass", mass);
     Expression bw_width  = 0;
     Expression bw_width0 = 0;
-    for (unsigned channel = 1; channel <= nChannels; ++channel ) 
+    for (unsigned channel = 1; channel <= nChannels; ++channel )
     {
       Expression g = Parameter(stub+"::g::"+std::to_string(channel));
       INFO("Will link to parameter: " << stub+"::g::"+std::to_string(channel) );
       thisPole.add(g, 1);
       if( dbexpressions != nullptr ){
-        dbexpressions->emplace_back( stub+"::g::"+std::to_string(channel), g); 
+        dbexpressions->emplace_back( stub+"::g::"+std::to_string(channel), g);
       }
       bw_width  = bw_width  + g*g*phsps[channel-1] / mass;
       bw_width0 = bw_width0 + g*g*bw_phase_space[channel-1] / mass;
@@ -77,23 +77,23 @@ DEFINE_LINESHAPE(GenericKmatrix)
   for(unsigned ch1 = 1; ch1 <= nChannels; ++ch1){
     for( unsigned ch2 = 1; ch2 <= nChannels; ++ch2 ){
       auto c1 = std::to_string(ch1);
-      auto c2 = std::to_string(ch2); 
+      auto c2 = std::to_string(ch2);
       if( ch1 > ch2 ) std::swap(c1,c2);
-      std::string nrShape = NamedParameter<std::string>(lineshapeModifier +"::"+c1+"::"+c2+"::nrShape", "flat");
-      Expression f1 = Parameter(lineshapeModifier+"::f1::"+c1+"::"+c2, 0);
+      std::string nrShape = NamedParameter<std::string>(lineshapeModifier+"::"+particleName+"::"+c1+"::"+c2+"::nrShape", "flat");
+      Expression f1 = Parameter(lineshapeModifier+"::"+particleName+"::f1::"+c1+"::"+c2, 0);
       if( nrShape == "flat") non_resonant[{ch1-1,ch2-1}] = f1;
-      else if( nrShape == "pole"){ 
-        Expression f2 = Parameter(lineshapeModifier+"::f2::"+c1+"::"+c2, 0);
-        Expression s0 = Parameter(lineshapeModifier+"::s0::"+c1+"::"+c2, 0);
+      else if( nrShape == "pole"){
+        Expression f2 = Parameter(lineshapeModifier+"::"+particleName+"::f2::"+c1+"::"+c2, 0);
+        Expression s0 = Parameter(lineshapeModifier+"::"+particleName+"::s0::"+c1+"::"+c2, 0);
         non_resonant[{ch1-1,ch2-1}] = (f1 + f2*sqrt(s)) / (s-s0);
       }
-      else WARNING("Unknown shape: " << nrShape); 
+      else WARNING("Unknown shape: " << nrShape);
     }
   }
   Tensor kMatrix = constructKMatrix(s, nChannels, poleConfigs);
 
   ADD_DEBUG_TENSOR(kMatrix   , dbexpressions);
-  kMatrix = kMatrix + non_resonant; 
+  kMatrix = kMatrix + non_resonant;
 
   Tensor propagator = getPropagator(kMatrix, phsps);
   ADD_DEBUG_TENSOR(non_resonant, dbexpressions);


### PR DESCRIPTION
Added particle name to GenericKmatrix identifier to allow for multiple kmatrices in the same model

This might not be the best solution for this and there might be already a solution that I was not aware of.

It worked for me in a Lb -> Lc D*0-bar K model where I put a 1+ and a 1- kMatrix in the D*0-bar K system

It looks like
```
Particle::DefaultModifier BL
...
Lambda(b)0[S1]{Ds1*-[GenericKmatrix]{Dbar0,K-},Lambda(c)+}_Re = LbToLcDsst_S1
...
BL::Ds1*-::kMatrix::nPoles 2
BL::Ds1*-::kMatrix::channels {
....
BL::Ds1*-::f1::1::1 = r_bkg_pole_1m * c_bkg_DstK_DstK
...
```
where the `::Ds1*-` is the part that has been added to the syntax and uniquely determines the KMatrix.