### PR TITLE
WIP: P-vector approach for GenericKmatrix

### DIFF
--- a/src/Lineshapes/GenericKmatrix.cpp
+++ b/src/Lineshapes/GenericKmatrix.cpp
@@ -104,19 +104,18 @@ DEFINE_LINESHAPE(GenericKmatrix)
   //we have all ingredients to build the production amplitude now
   //follow http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf eqns (48.34), (48.25)
   if(pa_type==PA_TYPE::PVec){
-    Expression A_0;//the object we'll return later: the amplitude in the 0th channel
-    for(unsigned channel = 0 ; channel < nChannels; ++channel) {
-      Expression P_c = 0;
-      for (unsigned pole = 1; pole <= nPoles; ++pole ){
-        auto const stub = particleName+"::pole::" + std::to_string(pole);
+    std::vector<Expression> P(nChannels,0);//the P-vector
+    Expression A_0 = 0;//the object we'll return later: the amplitude in the 0th channel
+    for(unsigned c = 0 ; c < nChannels; ++c){
+      for(unsigned R = 0; R < nPoles; ++R){
         //couplings of production amplitude to Kmatrix
-        Expression alpha = Parameter(stub+"::alpha::"+std::to_string(channel+1));
+        Expression alpha = Parameter(particleName+"::pole::"+std::to_string(R+1)+"::alpha::"+std::to_string(c+1));
         //sum P-vector over all poles (sum_R in (48.34))
-        P_c = P_c + (alpha * poleConfigs[pole-1].couplings[channel])/(poleConfigs[pole-1].s - s);
+        P[c] += (alpha * (poleConfigs[R].couplings[c]))/(poleConfigs[R].s - s);
       }
       //background for production amplitude (real number, different from the one in the Kmatrix)
-      P_c = P_c + Parameter(particleName+"::B::"+std::to_string(channel+1));
-      A_0 = A_0 + (propagator[{0,channel}] * P_c);
+      P[c] += Parameter(particleName+"::B::"+std::to_string(c+1));
+      A_0 += propagator[{c,0}] * P[c];
     }
     //TODO: implement n_0 (defined just below (48.19))
     return A_0;

--- a/src/Lineshapes/GenericKmatrix.cpp
+++ b/src/Lineshapes/GenericKmatrix.cpp
@@ -102,7 +102,7 @@ DEFINE_LINESHAPE(GenericKmatrix)
   ADD_DEBUG_TENSOR(non_resonant, dbexpressions);
 
   //we have all ingredients to build the production amplitude now
-  //follow http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf eqns (48.34), (48.25)
+  //follow https://doi.org/10.1007/s1010502a0002 eqns (9)-(13) modulo the Adler zero term (which is argued away in a fuzzy manner by citing a private communication)
   if(pa_type==PA_TYPE::PVec){
     std::vector<Expression> P(nChannels,0), a(nChannels,0), phi(nChannels,0);//the P-vector, a and phi coefficients
     Expression s_0 = Parameter(particleName+"::s0");
@@ -115,13 +115,13 @@ DEFINE_LINESHAPE(GenericKmatrix)
         Expression beta = 0;
         for(unsigned q = 0 ; q < nChannels; ++q){
           beta += a[q] * poleConfigs[alpha].couplings[q];
-          phi[k] += a[q] * non_resonant[{q,k}];
+          phi[k] += a[q] * non_resonant[{k,q}];
         }
-        P[k] += (beta * poleConfigs[alpha].couplings[k])/(poleConfigs[alpha].s - s) + phi[k] * (1+s_0)/(s-s_0);
+        P[k] += (beta * poleConfigs[alpha].couplings[k])/(poleConfigs[alpha].s - s) + phi[k] * (1.+s_0)/(s-s_0);
       }
-      F_0 += propagator[{k,0}] * P[k];
+      F_0 += propagator[{0,k}] * P[k];
     }
-    //TODO: implement n_a (defined just below (48.19))
+    //TODO: implement higher orbital angular momentum
     return F_0;
   }
   else if(pa_type==PA_TYPE::QVec){

--- a/src/Lineshapes/GenericKmatrix.cpp
+++ b/src/Lineshapes/GenericKmatrix.cpp
@@ -17,29 +17,26 @@
 #include "AmpGen/Utilities.h"
 #include "AmpGen/kMatrix.h"
 #include "AmpGen/CoupledChannel.h"
+#include "AmpGen/enum.h"
 
 using namespace AmpGen;
 using namespace AmpGen::fcn;
-
-enum PA_TYPE {PVec, QVec};
+namespace AmpGen{ make_enum(PA_TYPE, PVec, QVec); }
 
 DEFINE_LINESHAPE(GenericKmatrix)
 {
-  auto props        = ParticlePropertiesList::get( particleName );
-  Expression mass   = Parameter( particleName + "_mass", props->mass() );
-  INFO( "kMatrix modifier " << lineshapeModifier << " particle = " << particleName );
-  auto tokens = split(lineshapeModifier, '.' );
-  DEBUG("kMatrix modifier = " << lineshapeModifier << " nTokens = " << tokens.size() );
-  unsigned nPoles          = NamedParameter<unsigned>(lineshapeModifier+"::"+particleName+"::kMatrix::nPoles");
-  auto channels            = NamedParameter<std::string>(lineshapeModifier+"::"+particleName+"::kMatrix::channels").getVector();
-  auto const prod_amp_type = static_cast<PA_TYPE>(NamedParameter<int>(lineshapeModifier+"::"+particleName+"::kMatrix::production_amplitude",0).getVal());//PVec by default
-  unsigned nChannels = channels.size();
-  std::vector<Expression> phsps;
-  std::vector<Expression> bw_phase_space;
-  auto s0 = mass*mass;
+  auto props         = ParticlePropertiesList::get( particleName );
+  Expression mass    = Parameter( particleName + "_mass", props->mass() );
+  unsigned nPoles    = NamedParameter<unsigned>(particleName+"::kMatrix::nPoles");
+  auto channels      = NamedParameter<std::string>(particleName+"::kMatrix::channels").getVector();
+  auto const pa_type = NamedParameter<PA_TYPE>(particleName+"::kMatrix::production_amplitude",PA_TYPE::PVec);
+  auto nChannels     = channels.size();
+  auto s0            = mass*mass;
+  std::vector<Expression> phsps, bw_phase_space;
   ADD_DEBUG(s, dbexpressions );
   ADD_DEBUG(s0, dbexpressions );
   INFO("Initialising K-matrix with [nChannels = " << nChannels << ", nPoles = " << nPoles << "]");
+  //phase-space
   for( unsigned i = 0 ; i < channels.size(); i+=1 ){
     Particle p( channels[i] );
     INFO( p.decayDescriptor() );
@@ -48,10 +45,10 @@ DEFINE_LINESHAPE(GenericKmatrix)
     if( dbexpressions != nullptr ) dbexpressions->emplace_back("phsp_"+p.decayDescriptor(), *phsps.rbegin() ); //ADD_DEBUG( *phsps.rbegin(), dbexpressions);
 //    ADD_DEBUG( phaseSpace(s0,p,p.L()), dbexpressions );
   }
-  Tensor non_resonant( Tensor::dim(nChannels, nChannels) );
+  //pole configuration for kMatrix (see e.g. eq. (48.25) in http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf)
   std::vector<poleConfig> poleConfigs;
   for (unsigned pole = 1; pole <= nPoles; ++pole ){
-    std::string stub = lineshapeModifier+"::"+particleName+"::pole::" + std::to_string(pole);
+    std::string stub = particleName+"::pole::" + std::to_string(pole);
     Expression mass  = Parameter(stub + "::mass");
     DEBUG( "Will link to parameter: " << stub + "::mass");
     poleConfig thisPole(mass*mass);
@@ -77,22 +74,25 @@ DEFINE_LINESHAPE(GenericKmatrix)
     }
     poleConfigs.push_back(thisPole);
   }
+  //add non-resonant term to kMatrix (eq. (48.25) in http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf)
+  Tensor non_resonant( Tensor::dim(nChannels, nChannels) );
   for(unsigned ch1 = 1; ch1 <= nChannels; ++ch1){
     for( unsigned ch2 = 1; ch2 <= nChannels; ++ch2 ){
       auto c1 = std::to_string(ch1);
       auto c2 = std::to_string(ch2);
       if( ch1 > ch2 ) std::swap(c1,c2);
-      std::string nrShape = NamedParameter<std::string>(lineshapeModifier+"::"+particleName+"::"+c1+"::"+c2+"::nrShape", "flat");
-      Expression f1 = Parameter(lineshapeModifier+"::"+particleName+"::f1::"+c1+"::"+c2, 0);
+      std::string nrShape = NamedParameter<std::string>(particleName+"::"+c1+"::"+c2+"::nrShape", "flat");
+      Expression f1 = Parameter(particleName+"::f1::"+c1+"::"+c2, 0);
       if( nrShape == "flat") non_resonant[{ch1-1,ch2-1}] = f1;
       else if( nrShape == "pole"){
-        Expression f2 = Parameter(lineshapeModifier+"::"+particleName+"::f2::"+c1+"::"+c2, 0);
-        Expression s0 = Parameter(lineshapeModifier+"::"+particleName+"::s0::"+c1+"::"+c2, 0);
+        Expression f2 = Parameter(particleName+"::f2::"+c1+"::"+c2, 0);
+        Expression s0 = Parameter(particleName+"::s0::"+c1+"::"+c2, 0);
         non_resonant[{ch1-1,ch2-1}] = (f1 + f2*sqrt(s)) / (s-s0);
       }
       else WARNING("Unknown shape: " << nrShape);
     }
   }
+
   Tensor kMatrix = constructKMatrix(s, nChannels, poleConfigs);
 
   ADD_DEBUG_TENSOR(kMatrix, dbexpressions);
@@ -103,28 +103,28 @@ DEFINE_LINESHAPE(GenericKmatrix)
 
   //we have all ingredients to build the production amplitude now
   //follow http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf eqns (48.34), (48.25)
-  if(prod_amp_type==PA_TYPE::PVec){
+  if(pa_type==PA_TYPE::PVec){
     Expression A_0;//the object we'll return later: the amplitude in the 0th channel
     for(unsigned channel = 0 ; channel < nChannels; ++channel) {
       Expression P_c = 0;
       for (unsigned pole = 1; pole <= nPoles; ++pole ){
-        auto const stub = lineshapeModifier+"::"+particleName+"::pole::" + std::to_string(pole);
+        auto const stub = particleName+"::pole::" + std::to_string(pole);
         //couplings of production amplitude to Kmatrix
         Expression alpha = Parameter(stub+"::alpha::"+std::to_string(channel+1));
         //sum P-vector over all poles (sum_R in (48.34))
         P_c = P_c + (alpha * poleConfigs[pole-1].couplings[channel])/(poleConfigs[pole-1].s - s);
       }
       //background for production amplitude (real number, different from the one in the Kmatrix)
-      P_c = P_c + Parameter(lineshapeModifier+"::"+particleName+"::B::"+std::to_string(channel+1));
+      P_c = P_c + Parameter(particleName+"::B::"+std::to_string(channel+1));
       A_0 = A_0 + (propagator[{0,channel}] * P_c);
     }
     //TODO: implement n_0 (defined just below (48.19))
     return A_0;
   }
-  else if(prod_amp_type==PA_TYPE::QVec){
+  else if(pa_type==PA_TYPE::QVec){
     Expression M;
     for(unsigned i = 0 ; i < nChannels; ++i) M = M + kMatrix[{i,0}] * propagator[{0,i}];
     return M ; // * phsps[0];
   }
-  else throw std::runtime_error("This shouldn't happen. Currently supported types: P-vector approach (PA_TYPE::PVec==0) and Q-vector approach (PA_TYPE::QVec==1)");
+  else throw std::runtime_error("This shouldn't happen. Currently supported types: P-vector approach (PA_TYPE::PVec) and Q-vector approach (PA_TYPE::QVec)");
 }

--- a/src/Lineshapes/GenericKmatrix.cpp
+++ b/src/Lineshapes/GenericKmatrix.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <exception>
 
 #include "AmpGen/Expression.h"
 #include "AmpGen/Factory.h"
@@ -18,7 +19,9 @@
 #include "AmpGen/CoupledChannel.h"
 
 using namespace AmpGen;
-using namespace AmpGen::fcn; 
+using namespace AmpGen::fcn;
+
+enum PA_TYPE {PVec, QVec};
 
 DEFINE_LINESHAPE(GenericKmatrix)
 {
@@ -27,77 +30,101 @@ DEFINE_LINESHAPE(GenericKmatrix)
   INFO( "kMatrix modifier " << lineshapeModifier << " particle = " << particleName );
   auto tokens = split(lineshapeModifier, '.' );
   DEBUG("kMatrix modifier = " << lineshapeModifier << " nTokens = " << tokens.size() );
-  unsigned nPoles    = NamedParameter<unsigned>(     lineshapeModifier + "::kMatrix::nPoles");
-  auto channels    = NamedParameter<std::string>(lineshapeModifier + "::kMatrix::channels").getVector();
+  unsigned nPoles          = NamedParameter<unsigned>(lineshapeModifier+"::"+particleName+"::kMatrix::nPoles");
+  auto channels            = NamedParameter<std::string>(lineshapeModifier+"::"+particleName+"::kMatrix::channels").getVector();
+  auto const prod_amp_type = static_cast<PA_TYPE>(NamedParameter<int>(lineshapeModifier+"::"+particleName+"::kMatrix::production_amplitude",0).getVal());//PVec by default
   unsigned nChannels = channels.size();
   std::vector<Expression> phsps;
   std::vector<Expression> bw_phase_space;
   auto s0 = mass*mass;
   ADD_DEBUG(s, dbexpressions );
   ADD_DEBUG(s0, dbexpressions );
-  INFO("Initialising K-matrix with [nChannels = " << nChannels << ", nPoles = " << nPoles << "]"); 
+  INFO("Initialising K-matrix with [nChannels = " << nChannels << ", nPoles = " << nPoles << "]");
   for( unsigned i = 0 ; i < channels.size(); i+=1 ){
-    Particle p( channels[i] ); 
+    Particle p( channels[i] );
     INFO( p.decayDescriptor() );
     phsps.emplace_back( phaseSpace(s, p, p.L() ) );
     bw_phase_space.emplace_back( phaseSpace(s0, p, p.L() ) );
     if( dbexpressions != nullptr ) dbexpressions->emplace_back("phsp_"+p.decayDescriptor(), *phsps.rbegin() ); //ADD_DEBUG( *phsps.rbegin(), dbexpressions);
-//    ADD_DEBUG( phaseSpace(s0,p,p.L()), dbexpressions );  
+//    ADD_DEBUG( phaseSpace(s0,p,p.L()), dbexpressions );
   }
   Tensor non_resonant( Tensor::dim(nChannels, nChannels) );
   std::vector<poleConfig> poleConfigs;
   for (unsigned pole = 1; pole <= nPoles; ++pole ){
-    std::string stub = lineshapeModifier + "::pole::" + std::to_string(pole);
+    std::string stub = lineshapeModifier+"::"+particleName+"::pole::" + std::to_string(pole);
     Expression mass  = Parameter(stub + "::mass");
-    INFO( "Will link to parameter: " << stub + "::mass");
+    DEBUG( "Will link to parameter: " << stub + "::mass");
     poleConfig thisPole(mass*mass);
     if( dbexpressions != nullptr ) dbexpressions->emplace_back(stub+"::mass", mass);
     Expression bw_width  = 0;
     Expression bw_width0 = 0;
-    for (unsigned channel = 1; channel <= nChannels; ++channel ) 
-    {
+    for (unsigned channel = 1; channel <= nChannels; ++channel ){
       Expression g = Parameter(stub+"::g::"+std::to_string(channel));
-      INFO("Will link to parameter: " << stub+"::g::"+std::to_string(channel) );
+      DEBUG("Will link to parameter: " << stub+"::g::"+std::to_string(channel) );
       thisPole.add(g, 1);
-      if( dbexpressions != nullptr ){
-        dbexpressions->emplace_back( stub+"::g::"+std::to_string(channel), g); 
-      }
+      if(dbexpressions != nullptr) dbexpressions->emplace_back( stub+"::g::"+std::to_string(channel), g);
       bw_width  = bw_width  + g*g*phsps[channel-1] / mass;
       bw_width0 = bw_width0 + g*g*bw_phase_space[channel-1] / mass;
     }
-    for( unsigned channel = 1 ; channel <= nChannels; ++channel ){
-      Expression g = Parameter(stub+"::g::"+std::to_string(channel));
-      Expression BR = g*g*bw_phase_space[channel-1] / ( mass * bw_width0 );
-      ADD_DEBUG( BR, dbexpressions );
+    if( dbexpressions != nullptr ){
+      for( unsigned channel = 1 ; channel <= nChannels; ++channel ){
+        Expression g = Parameter(stub+"::g::"+std::to_string(channel));
+        Expression BR = g*g*bw_phase_space[channel-1] / ( mass * bw_width0 );
+        ADD_DEBUG( BR, dbexpressions );
+      }
+      ADD_DEBUG(bw_width, dbexpressions);
+      ADD_DEBUG(bw_width0, dbexpressions);
     }
-     ADD_DEBUG(bw_width, dbexpressions);
-     ADD_DEBUG(bw_width0, dbexpressions);
     poleConfigs.push_back(thisPole);
   }
   for(unsigned ch1 = 1; ch1 <= nChannels; ++ch1){
     for( unsigned ch2 = 1; ch2 <= nChannels; ++ch2 ){
       auto c1 = std::to_string(ch1);
-      auto c2 = std::to_string(ch2); 
+      auto c2 = std::to_string(ch2);
       if( ch1 > ch2 ) std::swap(c1,c2);
-      std::string nrShape = NamedParameter<std::string>(lineshapeModifier +"::"+c1+"::"+c2+"::nrShape", "flat");
-      Expression f1 = Parameter(lineshapeModifier+"::f1::"+c1+"::"+c2, 0);
+      std::string nrShape = NamedParameter<std::string>(lineshapeModifier+"::"+particleName+"::"+c1+"::"+c2+"::nrShape", "flat");
+      Expression f1 = Parameter(lineshapeModifier+"::"+particleName+"::f1::"+c1+"::"+c2, 0);
       if( nrShape == "flat") non_resonant[{ch1-1,ch2-1}] = f1;
-      else if( nrShape == "pole"){ 
-        Expression f2 = Parameter(lineshapeModifier+"::f2::"+c1+"::"+c2, 0);
-        Expression s0 = Parameter(lineshapeModifier+"::s0::"+c1+"::"+c2, 0);
+      else if( nrShape == "pole"){
+        Expression f2 = Parameter(lineshapeModifier+"::"+particleName+"::f2::"+c1+"::"+c2, 0);
+        Expression s0 = Parameter(lineshapeModifier+"::"+particleName+"::s0::"+c1+"::"+c2, 0);
         non_resonant[{ch1-1,ch2-1}] = (f1 + f2*sqrt(s)) / (s-s0);
       }
-      else WARNING("Unknown shape: " << nrShape); 
+      else WARNING("Unknown shape: " << nrShape);
     }
   }
   Tensor kMatrix = constructKMatrix(s, nChannels, poleConfigs);
 
-  ADD_DEBUG_TENSOR(kMatrix   , dbexpressions);
-  kMatrix = kMatrix + non_resonant; 
+  ADD_DEBUG_TENSOR(kMatrix, dbexpressions);
+  kMatrix = kMatrix + non_resonant;
 
   Tensor propagator = getPropagator(kMatrix, phsps);
   ADD_DEBUG_TENSOR(non_resonant, dbexpressions);
-  Expression M;
-  for(unsigned i = 0 ; i < nChannels; ++i) M = M + kMatrix[{i,0}] * propagator[{0,i}];
-  return M ; // * phsps[0];
+
+  //we have all ingredients to build the production amplitude now
+  //follow http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf eqns (48.34), (48.25)
+  if(prod_amp_type==PA_TYPE::PVec){
+    Expression A_0;//the object we'll return later: the amplitude in the 0th channel
+    for(unsigned channel = 0 ; channel < nChannels; ++channel) {
+      Expression P_c = 0;
+      for (unsigned pole = 1; pole <= nPoles; ++pole ){
+        auto const stub = lineshapeModifier+"::"+particleName+"::pole::" + std::to_string(pole);
+        //couplings of production amplitude to Kmatrix
+        Expression alpha = Parameter(stub+"::alpha::"+std::to_string(channel+1));
+        //sum P-vector over all poles (sum_R in (48.34))
+        P_c = P_c + (alpha * poleConfigs[pole-1].couplings[channel])/(poleConfigs[pole-1].s - s);
+      }
+      //background for production amplitude (real number, different from the one in the Kmatrix)
+      P_c = P_c + Parameter(lineshapeModifier+"::"+particleName+"::B::"+std::to_string(channel+1));
+      A_0 = A_0 + (propagator[{0,channel}] * P_c);
+    }
+    //TODO: implement n_0 (defined just below (48.19))
+    return A_0;
+  }
+  else if(prod_amp_type==PA_TYPE::QVec){
+    Expression M;
+    for(unsigned i = 0 ; i < nChannels; ++i) M = M + kMatrix[{i,0}] * propagator[{0,i}];
+    return M ; // * phsps[0];
+  }
+  else throw std::runtime_error("This shouldn't happen. Currently supported types: P-vector approach (PA_TYPE::PVec==0) and Q-vector approach (PA_TYPE::QVec==1)");
 }


### PR DESCRIPTION
First compiling and working (in the sense of it's generating something which doesn't look too insane) version of the P-vector approach for the GenericKmatrix implementation.

This PR sits on top of #6 

The P-vector approach is made default with the ability to change back to Q-vector with 
```
BL::XiPi0::kMatrix::production_amplitude 1 
```
which is internally casted to an enum. There is/should be a nicer solution for this.

The way of specifying the parameters of the production amplitude is different from what is implemented in the `kMatrix` implementation. Here's an example
```
### Production amplitude backgrounds
BL::XiPi0::B::1   2 0 0
...
Xi1620_alpha_LK    2 1.0 0
Xi1620_ra_LK_XiPi  2 1.0 0
BL::XiPi0::pole::1::alpha::1 = Xi1620_alpha_LK * Xi1620_ra_LK_XiPi
BL::XiPi0::pole::1::alpha::2 = Xi1620_alpha_LK
...
```

TODO:
- test and validate (how?)
- refactor (with an eye on how config files should best look)
- add n_a  (the combination of threshold and barrier factors in channel a, see http://pdg.lbl.gov/2019/reviews/rpp2019-rev-resonances.pdf below (48.19))

@tevans1260 could you please have a look and comment? 