### PR TITLE
bug fix for spin1 pol.vector

### DIFF
--- a/src/Chi2Estimator.cpp
+++ b/src/Chi2Estimator.cpp
@@ -69,7 +69,7 @@ void   Chi2Estimator::doChi2( const EventList_type& dataEvents, const EventList_
   for ( unsigned int i = 0; i < m_binning.size(); ++i ) {
     mc[i].rescale( total_data_weight / total_int_weight );
     double delta = data[i].val() - mc[i].val();
-    double tChi2 = delta * delta / ( data[i].val() + mc[i].var() );
+    double tChi2 = delta * delta / ( data[i].var() + mc[i].var() );
     chi2 += tChi2;
   }
   m_chi2  = chi2;

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -518,8 +518,8 @@ Tensor Particle::externalSpinTensor(const int& polState, DebugSymbols* db ) cons
     }
     if( m_spinBasis == spinBasis::Dirac ){
       Expression N = make_cse(1./(m*(pE + m)));
-      if( polState ==  1 ) return -Tensor({1.+ z *pX*N,  1i +  z*pY*N,  z*pZ*N    ,  z*m })/sqrt(2);
-      if( polState == -1 ) return  Tensor({1.+ zb*pX*N, -1i + zb*pY*N, zb*pZ*N    , zb*m })/sqrt(2);
+      if( polState ==  1 ) return -Tensor({1.+ z *pX*N,  1i +  z*pY*N,  z*pZ*N    ,  z/m })/sqrt(2);
+      if( polState == -1 ) return  Tensor({1.+ zb*pX*N, -1i + zb*pY*N, zb*pZ*N    , zb/m })/sqrt(2);
       if( polState ==  0 ) return  Tensor({pX*pZ*N    ,       pY*pZ*N, 1 + pZ*pZ*N, pZ/m });
     } 
   }


### PR DESCRIPTION
Bug fixes:

- Bug in spin-1 polarisation vector. After the fix, spinBasis::Dirac and spinBasis::Weyl give identical fit results.
- Chi2 computation should use var() instead of val() for weighted events. Not sure if the definition of the binning needs a fix for weighted events as well.