### PR TITLE
bug fix in orbitalRange calculation

### DIFF
--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -611,30 +611,16 @@ std::pair<size_t, size_t> Particle::orbitalRange( const bool& conserveParity ) c
           
   int min = std::abs( S - min_s12 );
   int max = std::abs( S + max_s12 );
-              
+
   for(int i=min_s12;i<=max_s12;i++){
-                  if(std::abs( S - i )< min)  min = std::abs( S - i );
-                  if(std::abs( S + i )> max)  max = std::abs( S + i );
-  }
-
-  int minOld = std::abs( S - s1 - s2 );
-  minOld     = std::min(minOld, std::abs( S + s1 - s2 ));
-  minOld     = std::min(minOld, std::abs( S - s1 + s2 ));
-  int maxOld = S + s1 + s2;
-
+      min = std::min(min, std::abs( S - i ));
+      max = std::max(max, std::abs( S + i ));
+  }        
   min /= 2;
   max /= 2;
-  minOld /= 2;
-  maxOld /= 2;
 
   DEBUG( "Name = " << m_name <<  " Range = " << min << " -> " << max << " conserving parity ? " << conserveParity << " 2J = " << S << " 2s1= " << s1 << " 2s2= " << s2 );
-
-  if( min != minOld || max != maxOld    ){
-        WARNING( "Clash in orbitalRange calculation, please check decay " << m_name << " -> " << daughter( 0 )->props()->name() << " " << daughter( 1 )->props()->name()  << " 2J = " << S << " 2s1= " << s1 << " 2s2= " << s2  );
-        WARNING( "Range set to " << min << " -> " << max );
-        WARNING( "Alternative Range = " << minOld << " -> " << maxOld );
-  }
-  
+    
   if ( conserveParity == false ) return {min, max}; 
   int l = min;
   for ( ; l < max + 1; ++l ) if( conservesParity(l) ) break;

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -605,13 +605,36 @@ std::pair<size_t, size_t> Particle::orbitalRange( const bool& conserveParity ) c
   const int S  = m_props->twoSpin();
   const int s1 = daughter(0)->props()->twoSpin();
   const int s2 = daughter(1)->props()->twoSpin();
-  int min = std::abs( S - s1 - s2 );
-  min     = std::min(min, std::abs( S + s1 - s2 ));
-  min     = std::min(min, std::abs( S - s1 + s2 ));
-  int max = S + s1 + s2;
+    
+  int min_s12 = std::abs( s1 - s2 );
+  int max_s12 = std::abs( s1 + s2 );
+          
+  int min = std::abs( S - min_s12 );
+  int max = std::abs( S + max_s12 );
+              
+  for(int i=min_s12;i<=max_s12;i++){
+                  if(std::abs( S - i )< min)  min = std::abs( S - i );
+                  if(std::abs( S + i )> max)  max = std::abs( S + i );
+  }
+
+  int minOld = std::abs( S - s1 - s2 );
+  minOld     = std::min(minOld, std::abs( S + s1 - s2 ));
+  minOld     = std::min(minOld, std::abs( S - s1 + s2 ));
+  int maxOld = S + s1 + s2;
+
   min /= 2;
   max /= 2;
-  DEBUG( "Range = " << min << " -> " << max << " conserving parity ? " << conserveParity << " J = " << S << " s1= " << s1 << " s2= " << s2 );
+  minOld /= 2;
+  maxOld /= 2;
+
+  DEBUG( "Name = " << m_name <<  " Range = " << min << " -> " << max << " conserving parity ? " << conserveParity << " 2J = " << S << " 2s1= " << s1 << " 2s2= " << s2 );
+
+  if( min != minOld || max != maxOld    ){
+        WARNING( "Clash in orbitalRange calculation, please check decay " << m_name << " -> " << daughter( 0 )->props()->name() << " " << daughter( 1 )->props()->name()  << " 2J = " << S << " 2s1= " << s1 << " 2s2= " << s2  );
+        WARNING( "Range set to " << min << " -> " << max );
+        WARNING( "Alternative Range = " << minOld << " -> " << maxOld );
+  }
+  
   if ( conserveParity == false ) return {min, max}; 
   int l = min;
   for ( ; l < max + 1; ++l ) if( conservesParity(l) ) break;

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -614,7 +614,6 @@ std::pair<size_t, size_t> Particle::orbitalRange( const bool& conserveParity ) c
 
   for(int i=min_s12;i<=max_s12;i++){
       min = std::min(min, std::abs( S - i ));
-      max = std::max(max, std::abs( S + i ));
   }        
   min /= 2;
   max /= 2;


### PR DESCRIPTION
This fixes a bug in the orbitalRange calculation.
Previously for eg V->V V the range was calculated to be 1 -> 3.
However, L=0 is possible with the LS coupling LS = 01.
The new implementation returns the range 0 -> 3.